### PR TITLE
Add a git-bisect script.

### DIFF
--- a/git-bisect.sh
+++ b/git-bisect.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+STATUS=0
+
+OPENSSL_DIR="/home/jaruga/git/openssl2"
+OPENSSL_INSTALL_DIR="${OPENSSL_DIR}/dest"
+PROGRAM_DIR="/home/jaruga/git/report-openssl-fips-ed25519"
+
+pushd "${OPENSSL_DIR}"
+git clean -fdx
+# See <https://github.com/openssl/openssl/blob/master/INSTALL.md>.
+./Configure \
+  --prefix="${OPENSSL_INSTALL_DIR}" \
+  --libdir=lib \
+  shared \
+  enable-fips \
+  enable-trace \
+  -O0 -g3
+  # -O0 -g3 -ggdb3 -gdwarf-5
+make "-j$(nproc)"
+make install
+popd
+
+pushd "${PROGRAM_DIR}"
+rm -f ed25519
+gcc \
+  -I "${OPENSSL_DIR}/dest/include/" \
+  -L "${OPENSSL_DIR}/dest/lib/" \
+  -O0 -g3 -ggdb3 -gdwarf-5 \
+  -o ed25519 ed25519.c -lcrypto
+if ! OPENSSL_CONF="${PROGRAM_DIR}/openssl_fips.cnf" \
+  OPENSSL_CONF_INCLUDE="${OPENSSL_INSTALL_DIR}/ssl" \
+  OPENSSL_MODULES="${OPENSSL_INSTALL_DIR}/lib/ossl-modules" \
+  LD_LIBRARY_PATH="${OPENSSL_INSTALL_DIR}/lib" \
+  ./ed25519 ed25519_pub.pem; then
+  echo "not ok."
+  STATUS=1
+else
+  echo "ok."
+fi
+popd
+
+exit "${STATUS}"

--- a/openssl_fips.cnf
+++ b/openssl_fips.cnf
@@ -1,0 +1,20 @@
+config_diagnostics = 1
+openssl_conf = openssl_init
+
+# Need to set the absolute path of the fipsmodule.cnf.
+# https://github.com/openssl/openssl/issues/17704
+.include /home/jaruga/git/openssl2/dest/ssl/fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+fips = fips_sect
+base = base_sect
+
+[base_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes


### PR DESCRIPTION
Added a logic to return the exit status 0 or 1 to avoid the error below.

```
+ OPENSSL_CONF=/home/jaruga/git/report-openssl-fips-ed25519/openssl_fips.cnf
+ OPENSSL_CONF_INCLUDE=/home/jaruga/git/openssl2/dest/ssl
+ OPENSSL_MODULES=/home/jaruga/git/openssl2/dest/lib/ossl-modules
+ LD_LIBRARY_PATH=/home/jaruga/git/openssl2/dest/lib
+ ./ed25519 ed25519_pub.pem
[DEBUG] Loaded providers:
  fips
  base
Could not parse PKey
PEM_write_bio_PUBKEY
/home/jaruga/git/report-openssl-fips-ed25519/git-bisect.sh: line 36: 656052 Segmentation fault      (core dumped) OPENSSL_CONF="${PROGRAM_DIR}/openssl_fips.cnf" OPENSSL_CONF_INCLUDE="${OPENSSL_INSTALL_DIR}/ssl" OPENSSL_MODULES="${OPENSSL_INSTALL_DIR}/lib/ossl-modules" LD_LIBRARY_PATH="${OPENSSL_INSTALL_DIR}/lib" ./ed25519 ed25519_pub.pem
error: bisect run failed: exit code 139 from '/home/jaruga/git/report-openssl-fips-ed25519/git-bisect.sh' is < 0 or >= 128
```