### PR TITLE
Add git-bisect-ruby-test.sh to find which commit makes a ruby/openssl test pass.

### DIFF
--- a/git-bisect-ruby-test.sh
+++ b/git-bisect-ruby-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+STATUS=0
+
+OPENSSL_DIR="/home/jaruga/git/openssl2"
+OPENSSL_INSTALL_DIR="${OPENSSL_DIR}/dest"
+RUBY_OPENSSL_DIR="/home/jaruga/git/ruby/openssl2"
+REPORT_DIR="/home/jaruga/git/report-openssl-fips-base-decoding-corruption"
+TEST_OPENSSL_FIPS_CONF="${REPORT_DIR}/openssl_fips.cnf"
+RUBY_TEST_FILE_NAME="test_pkey_test_compare.rb"
+# RUBY_TEST_FILE_NAME="test_pkey_test_x25519.rb"
+RUBY_TEST_FILE="${REPORT_DIR}/${RUBY_TEST_FILE_NAME}"
+
+cp -p "${RUBY_TEST_FILE}" "${RUBY_OPENSSL_DIR}/test/openssl/"
+
+pushd "${OPENSSL_DIR}"
+git clean -fdx
+# See <https://github.com/openssl/openssl/blob/master/INSTALL.md>.
+# no-docs option is available in OpenSSL 3.2+.
+./Configure \
+  --prefix="${OPENSSL_INSTALL_DIR}" \
+  --libdir=lib \
+  shared \
+  enable-fips \
+  enable-trace \
+  no-docs \
+  -O0 -g3 -ggdb3 -gdwarf-5
+make "-j$(nproc)"
+make install
+popd
+
+pushd "${RUBY_OPENSSL_DIR}"
+# Note run `bundle install` in advance.
+bundle exec rake clean
+rm -rf tmp/ lib/openssl.so
+
+MAKEFLAGS="V=1" \
+  RUBY_OPENSSL_EXTCFLAGS="-O0 -g3 -ggdb3 -gdwarf-5" \
+  bundle exec rake compile -- \
+  --enable-debug \
+  --with-openssl-dir="${OPENSSL_INSTALL_DIR}"
+
+if ! OPENSSL_CONF="${TEST_OPENSSL_FIPS_CONF}" \
+  ruby -I./lib -ropenssl "test/openssl/${RUBY_TEST_FILE_NAME}"; then
+  echo "not ok."
+  STATUS=1
+else
+  echo "ok."
+fi
+
+# Need to invert the return code when finding the fixed commit.
+# https://stackoverflow.com/questions/15407075/how-could-i-use-git-bisect-to-find-the-first-good-commit/17153598
+# > @DanielBöhmer: well, in that case you'll have to invert the return code, don't you?
+# > Correct, that's what is described in my answer.
+if [ "${STATUS}" = 1 ]; then
+  STATUS=0
+else
+  STATUS=1
+fi
+
+exit "${STATUS}"

--- a/openssl_fips.cnf
+++ b/openssl_fips.cnf
@@ -3,7 +3,7 @@ openssl_conf = openssl_init
 
 # Need to set the absolute path of the fipsmodule.cnf.
 # https://github.com/openssl/openssl/issues/17704
-.include /home/jaruga/git/openssl/dest/ssl/fipsmodule.cnf
+.include /home/jaruga/git/openssl2/dest/ssl/fipsmodule.cnf
 
 [openssl_init]
 providers = provider_sect

--- a/test_pkey_test_compare.rb
+++ b/test_pkey_test_compare.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require_relative "utils"
+
+class OpenSSL::TestPKeyTestCompare < OpenSSL::PKeyTestCase
+
+  def raw_initialize
+    pend "Ed25519 is not implemented" unless openssl?(1, 1, 1) # >= v1.1.1
+
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("foo123", "xxx") }
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("ED25519", "xxx") }
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_public_key("foo123", "xxx") }
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_public_key("ED25519", "xxx") }
+  end
+
+  def test_compare?
+    # pend_on_openssl_issue_21493
+
+    key1 = Fixtures.pkey("rsa1024")
+    key2 = Fixtures.pkey("rsa1024")
+    key3 = Fixtures.pkey("rsa2048")
+    key4 = Fixtures.pkey("dh-1")
+
+    assert_equal(true, key1.compare?(key2))
+    assert_equal(true, key1.public_key.compare?(key2))
+    assert_equal(true, key2.compare?(key1))
+    assert_equal(true, key2.public_key.compare?(key1))
+
+    assert_equal(false, key1.compare?(key3))
+
+    assert_raise(TypeError) do
+      key1.compare?(key4)
+    end
+  end
+end


### PR DESCRIPTION
This page was useful to implement the shell script.

https://stackoverflow.com/questions/15407075/how-could-i-use-git-bisect-to-find-the-first-good-commit/17153598

How to use:

```
$ git bisect start --term-new=fixed --term-old=unfixed
$ git bisect fixed 4c50610bdadbcf7aa6bbd968df67b8874234677b
$ git bisect unfixed cb8e64131e7ce230a9268bdd7cc4664868ff0dc9
$ git bisect run ~/git/report-openssl-fips-base-decoding-corruption/git-bisect-ruby-test.sh
```
